### PR TITLE
Generalise project_2D_to_3D function to project_2D_to_3D_plane

### DIFF
--- a/calib3d/calib.py
+++ b/calib3d/calib.py
@@ -266,6 +266,26 @@ class Calib():
         v = np.array([[0 if x is None else 1 for x in v]]).T
         return line_plane_intersection(self.C, d, P, v)
 
+    def project_2D_to_3D_plane(self, point2D: Point2D, point3D: Point3D, n) -> Point3D:
+        """ Using the calib object, project a 2D point in the 3D image space
+            given the normal vector and point of a 3D plane with which
+            it intersects.
+            Args:
+                point2D (Point2D): the 2D point to be projected
+                point3D (Point3D): a Point3D on the plane
+                n (np.ndarray): the normal vector of the plane
+            Returns:
+                The point in the 3D world that projects on `point2D` and for
+                which the given coordinates is given.
+        """
+        assert isinstance(point2D, Point2D), "Wrong argument type '{}'. Expected {}".format(type(point2D), Point2D)
+        assert isinstance(point3D, Point3D), "Wrong argument type '{}'. Expected {}".format(type(point3D), Point3D)
+
+        point2D = self.rectify(point2D)
+        X = Point3D(self.Pinv @ point2D.H)
+        d = (X - self.C)
+        return line_plane_intersection(self.C, d, point3D, n)
+
     def distort(self, point2D: Point2D) -> Point2D:
         """ Applies lens distortions to the given `point2D`.
         """

--- a/calib3d/calib.py
+++ b/calib3d/calib.py
@@ -259,12 +259,10 @@ class Calib():
         v = [X,Y,Z]
         assert sum([1 for x in v if x is None]) == 2
         assert isinstance(point2D, Point2D), "Wrong argument type '{}'. Expected {}".format(type(point2D), Point2D)
-        point2D = self.rectify(point2D)
-        X = Point3D(self.Pinv @ point2D.H)
-        d = (X - self.C)
+
         P = np.nan_to_num(Point3D(*v), 0)
         v = np.array([[0 if x is None else 1 for x in v]]).T
-        return line_plane_intersection(self.C, d, P, v)
+        return self.project_2D_to_3D_plane(point2D, P, v)
 
     def project_2D_to_3D_plane(self, point2D: Point2D, point3D: Point3D, n) -> Point3D:
         """ Using the calib object, project a 2D point in the 3D image space


### PR DESCRIPTION
Adds a front-facing function that allows users of the library to project 2D points onto arbitrary 3D planes.

Specifically generalises functionality of project_2D_to_3D function to create a project_2D_to_3D_plane function that takes a 2D point, a point on a plane, and the direction vector of the plane, and projects the 2D point onto the given plane. Makes project_2D_to_3D function use this generalised function.